### PR TITLE
Fix clearing session and lint errors

### DIFF
--- a/services/cloud-run/src/ai/agentSessionManager.ts
+++ b/services/cloud-run/src/ai/agentSessionManager.ts
@@ -147,7 +147,7 @@ export class AgentSessionManager {
         const sessionId = this.auth.uid;
 
         // Return if there is no session to clear for the user.
-        if (await !this.sessionStore.has(sessionId)) {
+        if (!(await this.sessionStore.has(sessionId))) {
             return true;
         }
 

--- a/services/cloud-run/src/index.ts
+++ b/services/cloud-run/src/index.ts
@@ -15,7 +15,6 @@
  */
 
 import express from 'express';
-import cors from 'cors';
 import { initializeApp } from 'firebase-admin/app';
 import routeHandlers from './routes';
 import logger from './logging/logger';

--- a/services/cloud-run/src/utils/utils.ts
+++ b/services/cloud-run/src/utils/utils.ts
@@ -73,7 +73,7 @@ export function createTextResponse(textMessage: string): TextResponse {
  * Convert any input to a ChatError.
  * If an enclosed error is of a type that contains a status code, it is also extracted.
  */
-export function createChatErrorFromError(error: any): ChatError {
+export function createChatErrorFromError(error: unknown): ChatError {
 
   if (error instanceof ChatError) {
     return error;
@@ -85,8 +85,9 @@ export function createChatErrorFromError(error: any): ChatError {
 
   if (error instanceof ClientError && error.stackTrace) {
     // A ClientError from VertexAI may have some additional details in its stacktrace.
-    const statusCode = (error.stackTrace as any).code || 500;
-    return new ChatError(statusCode, error.stackTrace.message, error);
+    const stackTrace = error.stackTrace as { code?: number; message: string };
+    const statusCode = stackTrace.code || 500;
+    return new ChatError(statusCode, stackTrace.message, error as Error);
   }
 
   if (error instanceof Error) {
@@ -94,7 +95,7 @@ export function createChatErrorFromError(error: any): ChatError {
   }
   
   // Fallback to return a generic error.
-  return new ChatError(500, 'An error occured', error);
+  return new ChatError(500, 'An error occured', error as Error);
 
 }
 


### PR DESCRIPTION
## Summary
- fix incorrect await expression in `clearSession`
- remove unused import from server setup
- improve error handling types
- run lint and build to ensure project compiles

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6885fdb58410832cad218946141d857d